### PR TITLE
No bash bootstrap

### DIFF
--- a/Code/User/settings.json
+++ b/Code/User/settings.json
@@ -276,9 +276,6 @@
   "terminal.integrated.enableFileLinks": false,
   "terminal.integrated.profiles.osx": {
     "bash": {
-      "env": {
-        "PREFERRED_SHELL": "bash"
-      },
       "icon": "terminal-bash",
       "path": "/usr/local/bin/bash"
     },

--- a/Code/User/windows/Code/User/settings.json
+++ b/Code/User/windows/Code/User/settings.json
@@ -267,9 +267,6 @@
   "terminal.integrated.defaultProfile.windows": "Cygwin bash",
   "terminal.integrated.profiles.windows": {
     "Cygwin bash": {
-      "env": {
-        "PREFERRED_SHELL": "bash"
-      },
       "icon": "terminal-bash",
       "path": "C:\\cygwin64\\bin\\bash.exe"
     }

--- a/bash/bashrc.bash
+++ b/bash/bashrc.bash
@@ -105,43 +105,6 @@ if [[ -z $HOME ]]; then
 fi
 
 # -----------------------------------------------------------------------------
-# Switch to alternate shell if necessary
-# -----------------------------------------------------------------------------
-
-if [[ -z $PREFERRED_SHELL ]]; then
-  case $HOSTNAME in
-    WS*)
-      # The way I launch Cygwin (via PuTTY + cygtermd) doesn't accommodate the
-      # concept of "login shell" -- if I start with anything besides /bin/bash,
-      # the session crashes immediately. I don't know why. -- ZGM 2019-03-01
-      PREFERRED_SHELL=$HOME/opt/bin/fish
-      ;;
-  esac
-
-  if [[ ! -x $PREFERRED_SHELL ]]; then
-    PREFERRED_SHELL=$(type -P fish 2>/dev/null)
-  fi
-fi
-
-: "${PREFERRED_SHELL:=$(type -P bash)}"
-
-if [[ $PREFERRED_SHELL != "$SHELL" ]]; then
-  export SHELL=$PREFERRED_SHELL
-
-  # Prevent shell from exiting if `exec` fails
-  shopt -s execfail
-
-  if shopt -pq login_shell; then
-    exec -l "$SHELL"
-  else
-    exec "$SHELL"
-  fi
-fi
-
-# We don't actually want to *keep* those settings, though.
-shopt -u execfail
-
-# -----------------------------------------------------------------------------
 # Other config files
 # -----------------------------------------------------------------------------
 

--- a/fish/functions/_wrappers/bash.fish
+++ b/fish/functions/_wrappers/bash.fish
@@ -1,3 +1,0 @@
-function bash --description 'GNU Bourne-Again SHell'
-    env PREFERRED_SHELL=(type -P bash) bash $argv
-end

--- a/fish/functions/execbash.fish
+++ b/fish/functions/execbash.fish
@@ -1,4 +1,0 @@
-function execbash --description 'GNU Bourne-Again SHell'
-    set -gx PREFERRED_SHELL (type -P bash)
-    exec bash
-end


### PR DESCRIPTION
Stop launching `fish` via `bash`. It may have been a good idea at the time, but now it's just unnecessary complexity.